### PR TITLE
Framework for interactive Ruby lessons

### DIFF
--- a/unit_1/lesson_1/ruby/Dockerfile
+++ b/unit_1/lesson_1/ruby/Dockerfile
@@ -1,0 +1,5 @@
+FROM 'ruby:2.5.0-alpine3.7'
+RUN gem install rainbow:3.0.0 rouge:3.1.0
+WORKDIR lesson
+COPY *.rb ./
+ENTRYPOINT [ "ruby", "lesson.rb" ]

--- a/unit_1/lesson_1/ruby/fragment_1.rb
+++ b/unit_1/lesson_1/ruby/fragment_1.rb
@@ -1,0 +1,7 @@
+# This will do X and Y
+#
+# This illustrates foo and bar!
+
+puts "The cheese is old and moldy, where is the bathroom?"
+
+puts "yay it worked!"

--- a/unit_1/lesson_1/ruby/fragment_2.rb
+++ b/unit_1/lesson_1/ruby/fragment_2.rb
@@ -1,0 +1,7 @@
+# This will do X and Y
+#
+# This illustrates foo and bar!
+
+puts "La la la la la la la"
+
+puts "FOOOOOOOOOOOOOOO"

--- a/unit_1/lesson_1/ruby/lesson.rb
+++ b/unit_1/lesson_1/ruby/lesson.rb
@@ -1,0 +1,39 @@
+require 'rainbow'
+require 'rouge'
+
+# An interactive Ruby lesson.
+module InteractiveLesson
+  def self.print_colorized(fragment)
+    formatter = Rouge::Formatters::Terminal256.new
+    lexer = Rouge::Lexers::Ruby.new
+    puts formatter.format lexer.lex fragment
+  end
+
+  def self.prompt(str)
+    puts Rainbow("—— Press ⏎  to #{str} ——").background(:silver)
+    STDIN.gets
+  end
+
+  def self.do_fragment(fragment, is_last)
+    print_colorized fragment
+    prompt 'execute the above code and see the results'
+    eval fragment
+    print "\n"
+    prompt 'continue' unless is_last
+  end
+
+  def self.fragments
+    paths = Dir.glob 'fragment_*.rb'
+    paths[0..-2].map { |path| [path, false] }
+                .push([paths[-1], true])
+  end
+
+  def self.start
+    print "\n"
+    fragments.each { |path, is_last| do_fragment IO.read(path), is_last }
+    congrats = '🎉 🎉 🎉  Congratulations, you’ve finished the lesson! 💪 💪 💪'
+    puts Rainbow(congrats).background(:silver).bright
+  end
+end
+
+InteractiveLesson.start

--- a/unit_1/lesson_1/ruby/start.sh
+++ b/unit_1/lesson_1/ruby/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+TAG=`pwd | openssl md5`
+
+# --quiet isn’t quite quiet enough
+docker build --quiet -t $TAG . > /dev/null
+
+docker run -it --rm $TAG


### PR DESCRIPTION
This creates a dummy lesson (unit 1, lesson 1, ruby) in order to build
and test the framework that’ll provide these interactive Ruby lessons.

I’m pretty happy with how this turned out, to the degree that once it’s
been proven out by implementing a few real lessons, maybe this should be
released as its own Gem.

@arsenerei please review. You can try this out by checking out the branch locally, navigating to the lesson dir, and running `./start.sh` — as long as you have Docker up and running, and you’re connected to the Internet (to download images and gems).

Closes #7