### PR TITLE
Fix network name on start script

### DIFF
--- a/ruby/unit_1/lesson_1/docker-compose.yml
+++ b/ruby/unit_1/lesson_1/docker-compose.yml
@@ -1,12 +1,16 @@
-version: '3'
+version: '3.5'
 services:
   lesson:
     build: .
     depends_on: ["kafka"]
+    networks:
+      - lesson
   kafka:
     image: "confluentinc/cp-kafka"
     depends_on: ["zookeeper"]
     expose: ["9092"]
+    networks:
+      - lesson
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
@@ -15,6 +19,11 @@ services:
   zookeeper:
     image: "confluentinc/cp-zookeeper"
     expose: ["2181"]
+    networks:
+      - lesson
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
+networks:
+  lesson:
+    name: lesson-network

--- a/ruby/unit_1/lesson_1/docker-compose.yml
+++ b/ruby/unit_1/lesson_1/docker-compose.yml
@@ -26,4 +26,4 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 networks:
   lesson:
-    name: lesson-network
+    name: unit-1

--- a/ruby/unit_1/lesson_2/start.sh
+++ b/ruby/unit_1/lesson_2/start.sh
@@ -5,7 +5,7 @@ set -ex
 cp ../../lesson.rb ../Dockerfile ../Gemfile ./
 
 ID=`docker build --quiet .`
-docker run -it --rm --network lesson1_default $ID
+docker run -it --rm --network lesson_1_default $ID
 
 # We’ll again leave the network up — i.e. not run
 # `docker-compose down` — because some more of the

--- a/ruby/unit_1/lesson_2/start.sh
+++ b/ruby/unit_1/lesson_2/start.sh
@@ -5,7 +5,7 @@ set -ex
 cp ../../lesson.rb ../Dockerfile ../Gemfile ./
 
 ID=`docker build --quiet .`
-docker run -it --rm --network lesson-network $ID
+docker run -it --rm --network unit-1 $ID
 
 # We’ll again leave the network up — i.e. not run
 # `docker-compose down` — because some more of the

--- a/ruby/unit_1/lesson_2/start.sh
+++ b/ruby/unit_1/lesson_2/start.sh
@@ -5,7 +5,7 @@ set -ex
 cp ../../lesson.rb ../Dockerfile ../Gemfile ./
 
 ID=`docker build --quiet .`
-docker run -it --rm --network lesson_1_default $ID
+docker run -it --rm --network lesson-network $ID
 
 # We’ll again leave the network up — i.e. not run
 # `docker-compose down` — because some more of the

--- a/ruby/unit_1/lesson_3/start.sh
+++ b/ruby/unit_1/lesson_3/start.sh
@@ -5,7 +5,7 @@ set -ex
 cp ../../lesson.rb ../Dockerfile ../Gemfile ./
 
 ID=`docker build --quiet .`
-docker run -it --rm --network lesson1_default $ID
+docker run -it --rm --network lesson_1_default $ID
 
 # We’ll again leave the network up — i.e. not run
 # `docker-compose down` — because some more of the

--- a/ruby/unit_1/lesson_3/start.sh
+++ b/ruby/unit_1/lesson_3/start.sh
@@ -5,7 +5,7 @@ set -ex
 cp ../../lesson.rb ../Dockerfile ../Gemfile ./
 
 ID=`docker build --quiet .`
-docker run -it --rm --network lesson-network $ID
+docker run -it --rm --network unit-1 $ID
 
 # We’ll again leave the network up — i.e. not run
 # `docker-compose down` — because some more of the

--- a/ruby/unit_1/lesson_3/start.sh
+++ b/ruby/unit_1/lesson_3/start.sh
@@ -5,7 +5,7 @@ set -ex
 cp ../../lesson.rb ../Dockerfile ../Gemfile ./
 
 ID=`docker build --quiet .`
-docker run -it --rm --network lesson_1_default $ID
+docker run -it --rm --network lesson-network $ID
 
 # We’ll again leave the network up — i.e. not run
 # `docker-compose down` — because some more of the

--- a/ruby/unit_1/lesson_4/start.sh
+++ b/ruby/unit_1/lesson_4/start.sh
@@ -5,7 +5,7 @@ set -ex
 cp ../../lesson.rb ../Dockerfile ../Gemfile ./
 
 ID=`docker build --quiet .`
-docker run -it --rm --network lesson1_default $ID
+docker run -it --rm --network lesson_1_default $ID
 
 # We’ll again leave the network up — i.e. not run
 # `docker-compose down` — because some more of the

--- a/ruby/unit_1/lesson_4/start.sh
+++ b/ruby/unit_1/lesson_4/start.sh
@@ -5,7 +5,7 @@ set -ex
 cp ../../lesson.rb ../Dockerfile ../Gemfile ./
 
 ID=`docker build --quiet .`
-docker run -it --rm --network lesson-network $ID
+docker run -it --rm --network unit-1 $ID
 
 # We’ll again leave the network up — i.e. not run
 # `docker-compose down` — because some more of the

--- a/ruby/unit_1/lesson_4/start.sh
+++ b/ruby/unit_1/lesson_4/start.sh
@@ -5,7 +5,7 @@ set -ex
 cp ../../lesson.rb ../Dockerfile ../Gemfile ./
 
 ID=`docker build --quiet .`
-docker run -it --rm --network lesson_1_default $ID
+docker run -it --rm --network lesson-network $ID
 
 # We’ll again leave the network up — i.e. not run
 # `docker-compose down` — because some more of the


### PR DESCRIPTION
Hello,

Seems that the [start.sh script](https://github.com/FundingCircle/learn-you-some-kafka/blob/f783e26c565528ab1a6ee380f57f5b548f331b0a/ruby/unit_1/lesson_2/start.sh#L8) is not working after lesson 1.

Debugging I noticed that the script rely in a specific network.

Reading the [docker documentation](https://docs.docker.com/compose/networking/) seems that the network name is based on the folder name, therefore the network should be `lesson_1` and not `lesson1`.

I'm not sure if this behaviour changes based the docker version though.

Currently I'm running `Version 18.03.1-ce-mac64 (24245)`
```
$ docker network ls | grep lesson
e74caeb37dec        lesson_1_default      bridge              local
```

We could also set the network name on `docker-compose.yml`. Would also be nice to share somehow the `start.sh` between folders to avoid the duplication.

BTW Thanks for the project it seems really nice.